### PR TITLE
Establish Fixed Pickle Protocol

### DIFF
--- a/morph/morphemes.py
+++ b/morph/morphemes.py
@@ -293,7 +293,7 @@ class MorphDb:
         if not os.path.exists(par):
             os.makedirs(par)
         f = gzip.open(path, 'wb')
-        pickle.dump(self.db, f, -1)
+        pickle.dump(self.db, f, 4)
         f.close()
 
     def load(self, path):  # FilePath -> m ()


### PR DESCRIPTION
The current code baseline defaults to the latest pickle protocol available in the version of python used in Anki. Since Anki is currently using python 3.8, the current pickle protocol is 5 (I should also note that protocol 5 was just introduced in python 3.8). I am proposing rolling back and fixing the pickle protocol to 4, for the time being, to ensure database readability with slightly older python versions within and outside of Anki. This takes care of the situation where users are using different versions of Anki between computers or analyzing the morphman databases for development outside of Anki with older builds of python.

I encountered this protocol incompatibility issue within Anaconda, since Anaconda only officially supports python 3.7 currently (pickle protocols up to 4). I feel the pickle protocol used for the database files should be explicitly documented and updated periodically in the baseline code, as the latest python version matures more past the point where a new protocol is introduced. This would allow for the new protocols to be introduced more gradually, giving users time to update Anki/python, and would alleviate a lot of confusion related to why a database can be read in one Anki/python version and not in another.